### PR TITLE
Fix LINQPad driver bug - DataSet name cannot start with a number

### DIFF
--- a/BigQueryDataContextDriver/SchemaBuilder.cs
+++ b/BigQueryDataContextDriver/SchemaBuilder.cs
@@ -114,13 +114,13 @@ namespace BigQuery.Linq
                 var typeCode = string.Join(Environment.NewLine + Environment.NewLine, tableCodes.Select(x => x.Code));
 
                 var template = $@"
-namespace {namespaceName}.@{schema.DatasetName.Replace("-", "_").Replace(":", "_")}
+namespace {namespaceName}.@_{schema.DatasetName.Replace("-", "_").Replace(":", "_")}
 {{
 {typeCode}
 }}";
 
                 code.Append(template);
-                namespaces.Add($"{namespaceName}.@{schema.DatasetName.Replace("-", "_").Replace(":", "_")}");
+                namespaces.Add($"{namespaceName}.@_{schema.DatasetName.Replace("-", "_").Replace(":", "_")}");
                 generatedCodes.AddRange(tableCodes);
             }
 

--- a/BigQueryDataContextDriver/SchemaBuilder.cs
+++ b/BigQueryDataContextDriver/SchemaBuilder.cs
@@ -113,14 +113,15 @@ namespace BigQuery.Linq
 
                 var typeCode = string.Join(Environment.NewLine + Environment.NewLine, tableCodes.Select(x => x.Code));
 
+                Func<string, string> toNamespaceName = x => (Regex.IsMatch(x, "^[0123456789]") ? "_": "") + x.Replace("-", "_").Replace(":", "_"); 
                 var template = $@"
-namespace {namespaceName}.@_{schema.DatasetName.Replace("-", "_").Replace(":", "_")}
+namespace {namespaceName}.@{toNamespaceName(schema.DatasetName)}
 {{
 {typeCode}
 }}";
 
                 code.Append(template);
-                namespaces.Add($"{namespaceName}.@_{schema.DatasetName.Replace("-", "_").Replace(":", "_")}");
+                namespaces.Add($"{namespaceName}.@{toNamespaceName(schema.DatasetName)}");
                 generatedCodes.AddRange(tableCodes);
             }
 


### PR DESCRIPTION
LINQPad driver do not work, when the `DataSet` name start with number char. 

- Add `_` prefix in `DatasetName` namespaces.
